### PR TITLE
Fixed directory browsing

### DIFF
--- a/src/cleanup.h
+++ b/src/cleanup.h
@@ -21,6 +21,7 @@
 #include <dirent.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <sys/stat.h>
 
 #include <openssl/bio.h>
 #include <openssl/ssl.h>

--- a/src/peterad/ctx.c
+++ b/src/peterad/ctx.c
@@ -42,12 +42,19 @@ load_decryption_certs_keys(const char *dirname)
         char path[strlen(dirname) + strlen(de->d_name) + 2];
         AUTO(FILE, file);
 
-        if (de->d_type != DT_REG)
+        if (de->d_type != DT_REG && de->d_type != DT_UNKNOWN)
             continue;
 
         strcpy(path, dirname);
         strcat(path, "/");
         strcat(path, de->d_name);
+
+        if (de->d_type == DT_UNKNOWN) {
+            struct stat sb;
+            if (! (stat(path, &sb) == 0 && S_ISREG(sb.st_mode))) {
+                continue;
+            }
+        }
 
         file = fopen(path, "r");
         if (file == NULL)


### PR DESCRIPTION
Fixed directory browsing for filesystems returning de->d_type == DT_UNKNOWN for regular files (e.g. XFS)
