### PR TITLE
Adjust openssl stack function use to fix pointer type mismatch warnin…

### DIFF
--- a/src/misc.c
+++ b/src/misc.c
@@ -125,7 +125,7 @@ verify_hostname(BIO *io, const char *hostname)
 
     sans = X509_get_ext_d2i(cert, NID_subject_alt_name, NULL, NULL);
     if (sans != NULL) {
-        for (int i = 0; i < sk_GENERAL_NAMES_num(sans); i++) {
+        for (int i = 0; i < sk_GENERAL_NAME_num(sans); i++) {
             const GENERAL_NAME *san;
 
             san = sk_GENERAL_NAME_value(sans, i);
@@ -136,12 +136,12 @@ verify_hostname(BIO *io, const char *hostname)
                 continue;
 
             if (equals(san->d.dNSName, hostname)) {
-                sk_GENERAL_NAMES_pop_free(sans, GENERAL_NAME_free);
+                sk_GENERAL_NAME_pop_free(sans, GENERAL_NAME_free);
                 return true;
             }
         }
 
-        sk_GENERAL_NAMES_pop_free(sans, GENERAL_NAME_free);
+        sk_GENERAL_NAME_pop_free(sans, GENERAL_NAME_free);
         return false;
 	}
 


### PR DESCRIPTION
…gs/errors.

In verify_hostname(), for a STACK_OF(GENERAL_NAME), use sk_GENERAL_NAME_*
instead of those for GENERAL_NAMES which is a different type

Signed-off-by: Andreas Stieger astieger@suse.com
